### PR TITLE
Resolve #9

### DIFF
--- a/src/components/CdsChart.vue
+++ b/src/components/CdsChart.vue
@@ -60,7 +60,7 @@ function pieChart(options) {
     pie = d3
       .pie()
       .sort(null)
-      //.padAngle(0.02)
+      .padAngle(0.02)
       .value(function(d) {
         return d.amount;
       });


### PR DESCRIPTION
è l'unica soluzione che ho trovato al problema delle slice troppo piccole nella vista di dettaglio dei CDS.